### PR TITLE
Script Fixes

### DIFF
--- a/src/misc/MissionRandomizer.cc
+++ b/src/misc/MissionRandomizer.cc
@@ -177,9 +177,11 @@ class MissionRandomizer : public RandomizerWithDebugInterface<MissionRandomizer>
                                            OriginalMission->endPos.y,
                                            OriginalMission->endPos.z);
 
+/*
         // Hostile Takeover | Set the flag to award % for unlocking Drugs type empire sites
         if (OriginalMission && OriginalMission->id == MISSION_HOSTILE_TAKEOVER)
             CTheScripts::GetGlobal<int> (657) = 1;
+*/
 
         OnMissionEnd (script);
         RandomMission   = nullptr;


### PR DESCRIPTION
- Fixes #32
- Fixes OBWAT gunshop menu softlock (vanilla bug)
- ~~Fixes completing Hostile Takeover locking out of % for unlocking Drugs type (vanilla bug)~~ commented out
- Blitzkrieg and Blitzkrieg Strikes Again code skips now check for act1